### PR TITLE
[nzbget] Allow mounting additional volumes

### DIFF
--- a/charts/nzbget/README.md
+++ b/charts/nzbget/README.md
@@ -72,7 +72,8 @@ The following tables lists the configurable parameters of the Sentry chart and t
 | `persistence.downloads.size`         | Size of persistent volume claim | `10Gi` |
 | `persistence.downloads.existingClaim`| Use an existing PVC to persist data | `nil` |
 | `persistence.downloads.storageClass` | Type of persistent volume claim | `-` |
-| `persistence.downloads.accessMode`  | Persistence access mode | `ReadWriteOnce` |
+| `persistence.downloads.accessMode`   | Persistence access mode | `ReadWriteOnce` |
+| `persistence.additional_volumes`     | Array of additional volumes to mount | `[]` |
 | `resources`                | CPU/Memory resource requests/limits | `{}` |
 | `nodeSelector`             | Node labels for pod assignment | `{}` |
 | `tolerations`              | Toleration labels for pod assignment | `[]` |

--- a/charts/nzbget/templates/deployment.yaml
+++ b/charts/nzbget/templates/deployment.yaml
@@ -62,6 +62,10 @@ spec:
             {{- if .Values.persistence.downloads.subPath }}
               subPath: {{ .Values.persistence.downloads.subPath }}
             {{ end }}
+            {{-  range .Values.persistence.additional_volumes }}
+            - mountPath: /{{ .name }}
+              name: {{ .name }}
+            {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:
@@ -79,6 +83,9 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
+     {{- if .Values.persistence.additional_volumes }}
+       {{- toYaml .Values.persistence.additional_volumes | nindent 6 }}
+     {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/nzbget/values.yaml
+++ b/charts/nzbget/values.yaml
@@ -96,6 +96,15 @@ persistence:
     # subPath: some-subpath
     accessMode: ReadWriteOnce
     size: 10Gi
+  additional_volumes: []
+  ## Add additional volumes (such as NFS volumes) that will be mounted in the
+  ## pod. This is useful if you wish to use different paths with categories
+  ## Volume will me mounted as /{name}
+  # - name: video
+  #   nfs:
+  #     server: 192.168.0.1
+  #     path: /some/path/to/video
+
 
 
 resources: {}


### PR DESCRIPTION
This is useful if some data exists in different paths and you wish to make use
of categories + paths. So you can have a volume for Movies and have a movies
category that points to this path.

Useful for when they exist on NFS, this allows you to easily attach NFS mounts
to the pod.


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[radarr]`)